### PR TITLE
Layout: brand tokens + header/footer + hero, add content wrapper

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,3 +36,16 @@ body {
   color: var(--brand-text);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Narrow content wrapper (keeps backgrounds full-bleed) */
+.content {
+  /* Approximate Apple.com content width */
+  max-width: 1068px;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+@media (min-width: 768px) {
+  .content {
+    padding-inline: 1.5rem;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
         className="bg-brand-primary text-white"
         /* To use a background image later: add 'bg-cover bg-center' and style={{ backgroundImage: "url('/path/to/image.jpg')" }} */
       >
-        <div className="mx-auto max-w-7xl px-4 py-16 sm:py-24 sm:px-6">
+        <div className="content py-16 sm:py-24 text-white">
           <div className="mx-auto max-w-3xl">
             <h1 className="text-3xl font-bold tracking-tight text-white sm:text-5xl text-center sm:text-left">
               Your Career Agent, always by your side.
@@ -34,8 +34,9 @@ export default function Home() {
       </section>
 
       {/* Audience cards */}
-      <section className="mx-auto mt-6 max-w-7xl px-4 sm:px-6">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <section className="mt-6">
+        <div className="content">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           <div className="rounded-xl border border-brand-muted bg-white p-6 shadow-sm/0 transition hover:shadow-md">
             <h2 className="text-xl font-semibold text-brand-text">For Job Seekers</h2>
             <ul className="mt-3 list-disc space-y-1 pl-5 text-brand-text/80">
@@ -52,16 +53,19 @@ export default function Home() {
               <li>Retention from day one</li>
             </ul>
           </div>
+          </div>
         </div>
       </section>
 
       {/* Shared Values */}
-      <section className="mx-auto mt-12 max-w-5xl px-4 sm:px-6">
-        <h3 className="text-2xl font-semibold text-brand-text">Work is about people.</h3>
-        <p className="mt-3 text-brand-text/80">
-          We believe careers and companies flourish when people feel supported.
-          That’s why we focus on the human experience behind every role and every hire.
-        </p>
+      <section className="mt-12">
+        <div className="content">
+          <h3 className="text-2xl font-semibold text-brand-text">Work is about people.</h3>
+          <p className="mt-3 text-brand-text/80">
+            We believe careers and companies flourish when people feel supported.
+            That’s why we focus on the human experience behind every role and every hire.
+          </p>
+        </div>
       </section>
     </main>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
 
   return (
     <header className="sticky top-0 z-50 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80 border-b border-brand-muted">
-      <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-3 sm:px-6">
+      <div className="content flex items-center gap-4 py-3">
         {/* Left: Logo */}
         <div className="shrink-0">
           <Link href="/" className="text-xl font-bold tracking-tight text-brand-text">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,20 @@ const config: Config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: "1rem",
+        md: "1.5rem",
+      },
+      screens: {
+        sm: "640px",
+        md: "768px",
+        lg: "1024px",
+        xl: "1120px",
+        "2xl": "1120px",
+      },
+    },
     extend: {
       colors: {
         brand: {
@@ -15,22 +29,6 @@ const config: Config = {
           primary: "var(--brand-primary)",
           accent: "var(--brand-accent)",
           muted: "var(--brand-muted)",
-          blue: {
-            50: "#F1F6FA",
-            100: "#D4E4F3",
-            300: "#78A9D6",
-            500: "#306EAA",
-            600: "#255789",
-            700: "#1A3E63",
-          },
-          orange: {
-            500: "#F26F21",
-            600: "#D35400",
-          },
-          gray: {
-            50: "#F5F7FA",
-            200: "#E5E5E5",
-          },
         },
       },
     },


### PR DESCRIPTION
Summary: Introduces a Randstad-like layout with Manpower-inspired brand tokens, a sticky header with auth, a simple footer, and a clean hero. Adds a narrow content wrapper to keep backgrounds full-bleed while constraining text width.

Changes:
- Brand tokens: CSS variables in `src/app/globals.css` (`--brand-{bg,text,primary,accent,muted}`) and Tailwind mapping.
- Header: new `Header` with logo, nav, auth (Google avatar via `next/image`, Sign out), sticky top and subtle border.
- Footer: lightweight footer with About/Contact/Privacy.
- Hero: full-bleed blue section using `bg-brand-primary`, white text, two CTAs with accessible contrast.
- Content width: added `.content` utility (max-width ~1068px; centered; responsive padding) and applied to header + page sections.
- Tailwind: content globs + minimal color extend kept; removed duplicate palette to avoid two sources of truth.
- Next images: `lh3.googleusercontent.com` allowed in `next.config.ts`.

Rationale:
- Keep backgrounds/images edge-to-edge while controlling readable text width.
- Use a single color source (globals.css @theme) to avoid Tailwind config hot-reload pitfalls.

Testing:
- Verify hero stays full-bleed blue (`bg-brand-primary`).
- Check header/footer backgrounds are full-bleed; inner content is constrained by `.content`.
- Confirm Google avatar loads when signed in.
- Run `npm run dev` and navigate all breakpoints.

Notes:
- Content width is centralized in `.content` (currently 1068px). Happy to adjust if you want tighter/looser.
- If you change Tailwind config in the future, restart the dev server to ensure classes regenerate.
